### PR TITLE
Fix/regla-negocio

### DIFF
--- a/src/main/java/com/mgcss/mgcss_track_7/domain/Solicitud.java
+++ b/src/main/java/com/mgcss/mgcss_track_7/domain/Solicitud.java
@@ -61,9 +61,9 @@ public class Solicitud {
         return asignado;
     }
 
-    public void cerrar() throws Exception{
+    public void cerrar() {
         if(this.estado != estadoSolicitudes.EN_PROCESO){
-            throw new Exception("No se puede cerrar una solititud que no esté en proceso\n");
+            throw new IllegalStateException("No se puede cerrar una solititud que no esté en proceso\n");
         }
         this.estado = estadoSolicitudes.CERRADA;
     }

--- a/src/main/java/com/mgcss/mgcss_track_7/domain/Solicitud.java
+++ b/src/main/java/com/mgcss/mgcss_track_7/domain/Solicitud.java
@@ -2,6 +2,7 @@ package com.mgcss.mgcss_track_7.domain;
 
 import java.util.Date;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -30,7 +31,10 @@ public class Solicitud {
     private Date fechaCreacion;
     private Date fechaCierre = null;
 
-    private estadoSolicitudes estado;
+    // Quitamos setter para no permitir mutar estado fuera de los métodos\
+    // que cumplan las reglas de negocio
+    @Setter(AccessLevel.NONE) 
+    private estadoSolicitudes estado = estadoSolicitudes.ABIERTA;
 
     public Solicitud(Long id, Cliente cliente, String descripcion, Tecnico tecnicoAsignado) {
         this.id = id;
@@ -38,7 +42,6 @@ public class Solicitud {
         this.descripcion = descripcion;
         this.tecnicoAsignado = tecnicoAsignado;
         this.fechaCreacion = new Date();
-        this.estado = estadoSolicitudes.ABIERTA;
     }
 
     public Solicitud(Long id, String descripcion, estadoSolicitudes estado) {
@@ -58,8 +61,15 @@ public class Solicitud {
         return asignado;
     }
 
+    public void cerrar() throws Exception{
+        if(this.estado != estadoSolicitudes.EN_PROCESO){
+            throw new Exception("No se puede cerrar una solititud que no esté en proceso\n");
+        }
+        this.estado = estadoSolicitudes.CERRADA;
+    }
+
     public void siguienteEstado(){
-        this.setEstado(estado.siguiente());
+        this.estado = this.estado.siguiente();
     }
 
 }

--- a/src/test/java/com/mgcss/mgcss_track_7/unit/domain/SolicitudTest.java
+++ b/src/test/java/com/mgcss/mgcss_track_7/unit/domain/SolicitudTest.java
@@ -1,7 +1,7 @@
 package com.mgcss.mgcss_track_7.unit.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import java.util.Date;
@@ -9,12 +9,33 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.mgcss.mgcss_track_7.domain.Cliente;
 import com.mgcss.mgcss_track_7.domain.Tecnico;
+import com.mgcss.mgcss_track_7.domain.Solicitud.estadoSolicitudes;
 import com.mgcss.mgcss_track_7.domain.Solicitud;
 
 
 
-@SpringBootTest
+
 class SolicitudTest {
+
+    @Test
+    void cerrarSolicitud(){
+        // flujo correcto
+        Solicitud solicitud_1 = new Solicitud(2L,"",estadoSolicitudes.EN_PROCESO);
+        solicitud_1.cerrar();
+        assertEquals(Solicitud.estadoSolicitudes.CERRADA, solicitud_1.getEstado());
+        
+        // flujo incorrecto 2
+        Solicitud solicitud_2 = new Solicitud();
+        assertEquals(Solicitud.estadoSolicitudes.ABIERTA, solicitud_1.getEstado());
+        solicitud_2.siguienteEstado();
+        solicitud_2.cerrar();
+        assertEquals(Solicitud.estadoSolicitudes.CERRADA, solicitud_2.getEstado());
+
+        // flujo incorrecto 
+        Solicitud solicitud_3 = new Solicitud();
+        assertThrows(RuntimeException.class, ()-> solicitud_3.cerrar());
+
+    }
 
     @Test
     void asignarTecnico_NoActivo_y_Activo() {
@@ -24,6 +45,8 @@ class SolicitudTest {
         tecnicoActivo.setActivo(true);
         assertEquals(true, solicitud.asignarTecnico(tecnicoActivo));
     }
+
+
 
     @Test
     void asignarTecnico_Activo_Ya_Asignado() {

--- a/src/test/java/com/mgcss/mgcss_track_7/unit/domain/SolicitudTest.java
+++ b/src/test/java/com/mgcss/mgcss_track_7/unit/domain/SolicitudTest.java
@@ -11,36 +11,25 @@ import com.mgcss.mgcss_track_7.domain.Tecnico;
 import com.mgcss.mgcss_track_7.domain.Solicitud.estadoSolicitudes;
 import com.mgcss.mgcss_track_7.domain.Solicitud;
 
-
-
-
 class SolicitudTest {
 
     @Test
-    void cerrarSolicitud(){
+    void cerrarSolicitud() {
         // flujo correcto
-        Solicitud solicitud_1 = new Solicitud(2L,"",estadoSolicitudes.EN_PROCESO);
-        try {
-            solicitud_1.cerrar();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        assertEquals(Solicitud.estadoSolicitudes.CERRADA, solicitud_1.getEstado());
-        
-        // flujo correcto 2
-        Solicitud solicitud_2 = new Solicitud();
-        assertEquals(Solicitud.estadoSolicitudes.ABIERTA, solicitud_2.getEstado());
-        solicitud_2.siguienteEstado();
-        try {
-            solicitud_2.cerrar();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        assertEquals(Solicitud.estadoSolicitudes.CERRADA, solicitud_2.getEstado());
+        Solicitud solicitud1 = new Solicitud(2L, "", estadoSolicitudes.EN_PROCESO);
+        solicitud1.cerrar();
+        assertEquals(Solicitud.estadoSolicitudes.CERRADA, solicitud1.getEstado());
 
-        // flujo incorrecto 
-        Solicitud solicitud_3 = new Solicitud();
-        assertThrows(Exception.class, ()-> solicitud_3.cerrar());
+        // flujo correcto 2
+        Solicitud solicitud2 = new Solicitud();
+        assertEquals(Solicitud.estadoSolicitudes.ABIERTA, solicitud2.getEstado());
+        solicitud2.siguienteEstado();
+        solicitud2.cerrar();
+        assertEquals(Solicitud.estadoSolicitudes.CERRADA, solicitud2.getEstado());
+
+        // flujo incorrecto
+        Solicitud solicitud3 = new Solicitud();
+        assertThrows(IllegalStateException.class, solicitud3::cerrar);
 
     }
 
@@ -52,8 +41,6 @@ class SolicitudTest {
         tecnicoActivo.setActivo(true);
         assertEquals(true, solicitud.asignarTecnico(tecnicoActivo));
     }
-
-
 
     @Test
     void asignarTecnico_Activo_Ya_Asignado() {
@@ -68,10 +55,9 @@ class SolicitudTest {
                 "***************************************************************************************************");
     }
 
-
     @Test
     void asignarTecnico_Doble_Solicitud() {
-        Solicitud solicitud = new Solicitud(1l,"Descripcion", Solicitud.estadoSolicitudes.ABIERTA);
+        Solicitud solicitud = new Solicitud(1l, "Descripcion", Solicitud.estadoSolicitudes.ABIERTA);
         Solicitud solicitud2 = new Solicitud();
         Tecnico tecnicoActivo = new Tecnico();
         tecnicoActivo.setActivo(true);
@@ -80,27 +66,27 @@ class SolicitudTest {
         System.out.println(
                 "***************************************************************************************************");
     }
+
     @Test
-	void testSolicitudGettersSetters() {
-		Solicitud solicitud = new Solicitud();
-		Cliente cliente = new Cliente();
-		Tecnico tecnico = new Tecnico();
-		Date fecha = new Date();
+    void testSolicitudGettersSetters() {
+        Solicitud solicitud = new Solicitud();
+        Cliente cliente = new Cliente();
+        Tecnico tecnico = new Tecnico();
+        Date fecha = new Date();
 
-		solicitud.setId(100L);
-		solicitud.setCliente(cliente);
-		solicitud.setDescripcion("Error de software");
-		solicitud.setTecnicoAsignado(tecnico);
-		solicitud.setFechaCreacion(fecha);
-		solicitud.setFechaCierre(fecha);
-		
+        solicitud.setId(100L);
+        solicitud.setCliente(cliente);
+        solicitud.setDescripcion("Error de software");
+        solicitud.setTecnicoAsignado(tecnico);
+        solicitud.setFechaCreacion(fecha);
+        solicitud.setFechaCierre(fecha);
 
-		assertEquals(100L, solicitud.getId());
-		assertEquals(cliente, solicitud.getCliente());
-		assertEquals("Error de software", solicitud.getDescripcion());
-		assertEquals(tecnico, solicitud.getTecnicoAsignado());
-		assertEquals(fecha, solicitud.getFechaCreacion());
-		assertEquals(fecha, solicitud.getFechaCierre());
-	}
+        assertEquals(100L, solicitud.getId());
+        assertEquals(cliente, solicitud.getCliente());
+        assertEquals("Error de software", solicitud.getDescripcion());
+        assertEquals(tecnico, solicitud.getTecnicoAsignado());
+        assertEquals(fecha, solicitud.getFechaCreacion());
+        assertEquals(fecha, solicitud.getFechaCierre());
+    }
 
 }

--- a/src/test/java/com/mgcss/mgcss_track_7/unit/domain/SolicitudTest.java
+++ b/src/test/java/com/mgcss/mgcss_track_7/unit/domain/SolicitudTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import java.util.Date;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import com.mgcss.mgcss_track_7.domain.Cliente;
 import com.mgcss.mgcss_track_7.domain.Tecnico;
@@ -21,19 +20,27 @@ class SolicitudTest {
     void cerrarSolicitud(){
         // flujo correcto
         Solicitud solicitud_1 = new Solicitud(2L,"",estadoSolicitudes.EN_PROCESO);
-        solicitud_1.cerrar();
+        try {
+            solicitud_1.cerrar();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         assertEquals(Solicitud.estadoSolicitudes.CERRADA, solicitud_1.getEstado());
         
-        // flujo incorrecto 2
+        // flujo correcto 2
         Solicitud solicitud_2 = new Solicitud();
-        assertEquals(Solicitud.estadoSolicitudes.ABIERTA, solicitud_1.getEstado());
+        assertEquals(Solicitud.estadoSolicitudes.ABIERTA, solicitud_2.getEstado());
         solicitud_2.siguienteEstado();
-        solicitud_2.cerrar();
+        try {
+            solicitud_2.cerrar();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         assertEquals(Solicitud.estadoSolicitudes.CERRADA, solicitud_2.getEstado());
 
         // flujo incorrecto 
         Solicitud solicitud_3 = new Solicitud();
-        assertThrows(RuntimeException.class, ()-> solicitud_3.cerrar());
+        assertThrows(Exception.class, ()-> solicitud_3.cerrar());
 
     }
 
@@ -86,7 +93,7 @@ class SolicitudTest {
 		solicitud.setTecnicoAsignado(tecnico);
 		solicitud.setFechaCreacion(fecha);
 		solicitud.setFechaCierre(fecha);
-		solicitud.setEstado(Solicitud.estadoSolicitudes.EN_PROCESO);
+		
 
 		assertEquals(100L, solicitud.getId());
 		assertEquals(cliente, solicitud.getCliente());
@@ -94,7 +101,6 @@ class SolicitudTest {
 		assertEquals(tecnico, solicitud.getTecnicoAsignado());
 		assertEquals(fecha, solicitud.getFechaCreacion());
 		assertEquals(fecha, solicitud.getFechaCierre());
-		assertEquals(Solicitud.estadoSolicitudes.EN_PROCESO, solicitud.getEstado());
 	}
 
 }

--- a/src/test/java/com/mgcss/mgcss_track_7/unit/domain/TecnicoTest.java
+++ b/src/test/java/com/mgcss/mgcss_track_7/unit/domain/TecnicoTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.test.context.SpringBootTest;
-
 
 import com.mgcss.mgcss_track_7.domain.Tecnico;
 import com.mgcss.mgcss_track_7.domain.Solicitud;

--- a/src/test/java/com/mgcss/mgcss_track_7/unit/domain/TecnicoTest.java
+++ b/src/test/java/com/mgcss/mgcss_track_7/unit/domain/TecnicoTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import com.mgcss.mgcss_track_7.domain.Tecnico;
 import com.mgcss.mgcss_track_7.domain.Solicitud;
 
-@SpringBootTest
+
 class TecnicoTest {
 
 

--- a/src/test/java/com/mgcss/mgcss_track_7/unit/service/ServicioSolicitudTest.java
+++ b/src/test/java/com/mgcss/mgcss_track_7/unit/service/ServicioSolicitudTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mockito;
 
 import com.mgcss.mgcss_track_7.domain.Solicitud;
 import com.mgcss.mgcss_track_7.domain.Tecnico;
+import com.mgcss.mgcss_track_7.domain.Solicitud.estadoSolicitudes;
 import com.mgcss.mgcss_track_7.infraestrucure.persistence.SolicitudRepositorio;
 import com.mgcss.mgcss_track_7.service.ServicioSolicitud;
 
@@ -75,10 +76,9 @@ class ServicioSolicitudTest {
         SolicitudRepositorio repositorio = Mockito.mock(SolicitudRepositorio.class);
         ServicioSolicitud servicio = new ServicioSolicitud(repositorio);
 
-        Solicitud solicitud = new Solicitud();
-        solicitud.setId(21L);
-        solicitud.setEstado(Solicitud.estadoSolicitudes.ABIERTA);
-
+        Solicitud solicitud = new Solicitud(21L, "", estadoSolicitudes.ABIERTA);
+        
+        
         when(repositorio.findById(21L)).thenReturn(Optional.of(solicitud));
         when(repositorio.save(solicitud)).thenReturn(solicitud);
 
@@ -109,10 +109,8 @@ class ServicioSolicitudTest {
         SolicitudRepositorio repositorio = Mockito.mock(SolicitudRepositorio.class);
         ServicioSolicitud servicio = new ServicioSolicitud(repositorio);
         Tecnico tecnico = new Tecnico();
-        Solicitud solicitud = new Solicitud();
+        Solicitud solicitud = new Solicitud(21L,"", estadoSolicitudes.EN_PROCESO);
 
-        solicitud.setId(21L);
-        solicitud.setEstado(Solicitud.estadoSolicitudes.EN_PROCESO);
         tecnico.setActivo(true);
         tecnico.setTrabajando(false);
         solicitud.asignarTecnico(tecnico);


### PR DESCRIPTION
Arreglada lógica que no cumplía la regla de negocio "**No se puede cerrar una solicitud si no está en estado EN_PROCESO.**"
Encapsular estados para poder cambiarlo únicamente desde métodos que cumplan las reglas de negocio.
Creados tests que comprueben los distintos estados.
Refactorización de algunos tests que hacían uso del setter de estado