### PR TITLE
ci(release): workflow para automatizar release con versionado

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: mv target/*.jar target/mgcss-track-7-${{ github.ref_name }}.jar
 
       - name: Login en Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee #v4.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
           docker push adrianma13/mgcss-track-7:latest
 
       - name: Publicar Release en GitHub
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda #v3.0
         with:
           generate_release_notes: true
           files: target/mgcss-track-7-${{ github.ref_name }}.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release Pipeline
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  quality-gate:
+    name: Quality Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codigo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configurar Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Ejecutar tests y analisis Sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn clean -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=javiiariass_mgcss-track-7
+
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+    needs: quality-gate
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout codigo
+        uses: actions/checkout@v4
+
+      - name: Configurar Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Compilar y generar artefacto
+        run: mvn clean package -DskipTests
+
+      - name: Renombrar artefacto
+        run: mv target/*.jar target/mgcss-track-7-${{ github.ref_name }}.jar
+
+      - name: Login en Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Construir y publicar imagen Docker
+        run: |
+          docker build -t adrianma13/mgcss-track-7:${{ github.ref_name }} -t adrianma13/mgcss-track-7:latest .
+          docker push adrianma13/mgcss-track-7:${{ github.ref_name }}
+          docker push adrianma13/mgcss-track-7:latest
+
+      - name: Publicar Release en GitHub
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: target/mgcss-track-7-${{ github.ref_name }}.jar

--- a/docs/cheatsheet-tag.md
+++ b/docs/cheatsheet-tag.md
@@ -1,0 +1,13 @@
+1. Desarrollas en rama feature/xxx
+2. Haces PR a main con Conventional Commits
+3. Merge a main
+4. Cuando decides liberar:
+   git tag vMAJOR.MINOR.PATCH
+        o 
+        git tag -a vMAJOR.MINOR.PATCH
+   git push origin v1.0.2  (por ejemplo)
+5. El workflow release.yml se dispara automaticamente:
+   - Quality Gate (tests + Sonar) -> si falla, se detiene
+   - Build .jar
+   - Build + push imagen Docker a Docker Hub
+   - Publica Release en GitHub con .jar adjunto

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,61 @@
+# Release Notes
+
+## Estrategia de versionado
+
+Este proyecto sigue **Versionado Semantico (SemVer)**: `MAJOR.MINOR.PATCH`
+
+| Componente | Significado | Ejemplo |
+|---|---|---|
+| MAJOR | Cambios incompatibles con la version anterior | Cambio de API REST, eliminacion de endpoints |
+| MINOR | Nueva funcionalidad compatible hacia atras | Nuevo endpoint, nueva entidad |
+| PATCH | Correcciones de errores y mejoras menores | Bugfix, typo, refactor sin impacto funcional |
+
+## Historial de versiones
+
+### v1.0.0 - Primera Release Estable
+
+Primera version estable del sistema de gestion de solicitudes.
+
+**Funcionalidades:**
+- Modelo de dominio: Solicitud, Tecnico, Cliente con reglas de negocio
+- Gestion de estados (ABIERTA -> EN_PROCESO -> CERRADA) con metodo `siguienteEstado()`
+- Logica de reabrir solicitudes cerradas con reasignacion de tecnico
+- Historico de cambios de estado
+- Tiempo de resolucion diferenciado (24 dias PREMIUM, 48 dias STANDARD)
+- Capa de persistencia JPA (PostgreSQL + H2 para tests)
+- Capa API REST con controladores, DTOs y mappers
+- Swagger/OpenAPI integrado
+- Pipeline CI con SonarCloud + JaCoCo
+- Conventional Commits
+
+### v1.0.1 - Integracion Docker
+
+**Tipo de cambio:** PATCH
+
+**Cambios:**
+- Dockerfile basado en `eclipse-temurin:17-jre-alpine`
+- `docker-compose.yml` con servicio app + PostgreSQL
+- Imagen publicada en DockerHub (`adrianma13/mgcss-track-7`)
+
+**Justificacion PATCH:** Cambio de infraestructura/build sin modificacion funcional ni de API.
+
+### v1.0.2 - (Proxima release planificada)
+
+**Tipo de cambio:** PATCH
+
+**Commits desde v1.0.1:**
+- `refactor(structure): typo en structure` - Correccion menor
+
+**Justificacion PATCH:**
+- No hay nuevas funcionalidades (descarta MINOR)
+- No hay cambios incompatibles (descarta MAJOR)
+- Solo contiene una correccion menor de refactorizacion
+
+## Proceso de release
+
+1. Los commits siguen Conventional Commits (`feat:`, `fix:`, `refactor:`, etc.)
+2. Se crea un tag con formato `vMAJOR.MINOR.PATCH`
+3. El push del tag dispara el workflow `release.yml`
+4. El workflow ejecuta Quality Gate (tests + Sonar) antes de liberar
+5. Se genera artefacto `.jar`, imagen Docker y Release en GitHub
+6. Nunca se libera una version si el Quality Gate no pasa


### PR DESCRIPTION
- Añadido workflow `release.yml` que se dispara al hacer push de un tag `v*`
- Incluye Quality Gate (tests + Sonar) obligatorio antes de liberar
- Genera artefacto `.jar`
- Construye y publica imagen Docker en DockerHub 
- Publica Release en GitHub con release notes autogeneradas
- Documentadas notas de versionado y miniguía del uso de tags en git

Closes javiiariass/mgcss-track-7#53