### PR TITLE
fix(ci): quitar duplicidad && arreglo Shallow clone Sonar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Descargar código
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Configurar Java
         uses: actions/setup-java@v3
@@ -25,6 +27,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn clean -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=javiiariass_mgcss-track-7
 
-      - name: Ejecutar tests
-        run: mvn test
+      # con clean verigy es suficiente
+      # - name: Ejecutar tests
+      #   run: mvn test
 


### PR DESCRIPTION
- mvn test es innecesario si ya estamos ejecutando mvn clean verify
- SonarCloud daba warning por descarga parcial de historial de commits.